### PR TITLE
Trivial change so that can make a PR to trigger rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,4 +118,3 @@ Feedstock Maintainers
 =====================
 
 * [@paulsaxe](https://github.com/paulsaxe/)
-


### PR DESCRIPTION
@conda-forge-admin, please restart ci

Removed a blank line from README.md so that I could make a PR, hopefully causing the CI to restart since the `seamm-util` dependency now exists. Hopefully I don't need to bump the build number because there has been no successful build.